### PR TITLE
feat: init dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.editorconfig
+.eslintignore
+.eslintrc.js
+.gitignore
+.husky
+/.git
+/.github
+/dist
+/node_modules
+/scripts
+/tests
+LICENSE
+README.md
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM docker.io/library/node:18-alpine as build
+
+WORKDIR /app
+
+COPY ["package.json", "package-lock.json*", "./"]
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+
+FROM docker.io/library/nginx:1.23
+
+EXPOSE 80
+COPY --from=build /app/dist/ /usr/share/nginx/html


### PR DESCRIPTION
Initialize simple `Dockerfile`. Two stage build: build static assets, then copy content to the [nginx](https://hub.docker.com/_/nginx) base image. `nginx` is chosen because of it lightweight and easy customization/configuration.
So far, no build automation.

Example of usage in `docker-compose.yml`:
```yaml
services:
  metis-frontend:
    build:
      context: ./metis-gui
    ports:
      - "28002:80"
```