### PR TITLE
Delete only files on npm run clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"test": "jest src",
 		"test:watch": "npm run test -- --watch",
 		"size": "size-limit",
-		"clean": "rm -rf ./dist",
+		"clean": "find ./dist/ -type f -delete",
 		"husky:init": "npx husky install"
 	},
 	"engines": {


### PR DESCRIPTION
Remove files but not directories on `npm run clean` & co.
Pros: don't broke bind mounts.
Cons: dependency on `find` utility.