### PR TITLE
60-runtime-config.sh: get src and dst from env

### DIFF
--- a/.docker/docker-entrypoint.d/60-runtime-cfg.sh
+++ b/.docker/docker-entrypoint.d/60-runtime-cfg.sh
@@ -1,17 +1,18 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-set -e
+set -e pipefail
 
-TARGET="/srv/index.html"
+: "${METIS_RUNTIME_CONFIG_SRC:=/srv/index.html}"
+: "${METIS_RUNTIME_CONFIG_DEST:=/srv/index.html}"
 PREFIX="window._METIS_RUNTIME_CONFIG = "
 
 if [ -n "${METIS_RUNTIME_CONFIG+x}" ]; then
     echo "Injecting runtime config..."
     TMP=$(mktemp)
-    cp --attributes-only --preserve "$TARGET" "$TMP"
-    sed -e "s/$PREFIX{}/$PREFIX\${METIS_RUNTIME_CONFIG}/" "$TARGET" \
+    cp --attributes-only --preserve "$METIS_RUNTIME_CONFIG_SRC" "$TMP"
+    sed -e "s/$PREFIX{}/$PREFIX\${METIS_RUNTIME_CONFIG}/" "$METIS_RUNTIME_CONFIG_SRC" \
         | envsubst \$METIS_RUNTIME_CONFIG > "$TMP"
-    mv "$TMP" "$TARGET"
+    mv "$TMP" "$METIS_RUNTIME_CONFIG_DEST"
 fi
 
 exit 0


### PR DESCRIPTION
Ability to set source and target `index.html` in environment variables. Default behavior, not changed.