### PR TITLE
build(60-runtime-config.sh): set permissions instead of copy

### DIFF
--- a/.docker/docker-entrypoint.d/60-runtime-cfg.sh
+++ b/.docker/docker-entrypoint.d/60-runtime-cfg.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e pipefail
+set -euo pipefail
 
 : "${METIS_RUNTIME_CONFIG_SRC:=/srv/index.html}"
 : "${METIS_RUNTIME_CONFIG_DEST:=/srv/index.html}"
@@ -9,7 +9,8 @@ PREFIX="window._METIS_RUNTIME_CONFIG = "
 if [ -n "${METIS_RUNTIME_CONFIG+x}" ]; then
     echo "Injecting runtime config..."
     TMP=$(mktemp)
-    cp --attributes-only --preserve "$METIS_RUNTIME_CONFIG_SRC" "$TMP"
+    touch "$TMP"
+    chmod 644 "$TMP"
     sed -e "s/$PREFIX{}/$PREFIX\${METIS_RUNTIME_CONFIG}/" "$METIS_RUNTIME_CONFIG_SRC" \
         | envsubst \$METIS_RUNTIME_CONFIG > "$TMP"
     mv "$TMP" "$METIS_RUNTIME_CONFIG_DEST"


### PR DESCRIPTION
Fix permissions when `index.html` mounted from outside.